### PR TITLE
Disable entities while parsing XML

### DIFF
--- a/remove_leading_place.py
+++ b/remove_leading_place.py
@@ -44,7 +44,8 @@ def ocr_to_dict(url):
 
     parser = lxml.etree.XMLParser(ns_clean=True,
                                   recover=True,
-                                  encoding='utf-8')
+                                  encoding='utf-8',
+                                  resolve_entities=False)
 
     xml = lxml.etree.fromstring(text, parser=parser)
 


### PR DESCRIPTION
If an attacker supplies a url returning malicious XML content, they may be able to leak internal information such as files, and/or cause a denial of service. 

Entrypoint:
https://github.com/KBNLresearch/digger/blob/399d0d5f4d50d36cce74047cf32c3f93a745f698/remove_leading_place.py#L15

Getting into `ocr_to_dict`:
https://github.com/KBNLresearch/digger/blob/399d0d5f4d50d36cce74047cf32c3f93a745f698/remove_leading_place.py#L25

User-controlled URL request:
https://github.com/KBNLresearch/digger/blob/399d0d5f4d50d36cce74047cf32c3f93a745f698/remove_leading_place.py#L42

Vulnerable parser declaration:
https://github.com/KBNLresearch/digger/blob/399d0d5f4d50d36cce74047cf32c3f93a745f698/remove_leading_place.py#L45-L47

Sink:
https://github.com/KBNLresearch/digger/blob/399d0d5f4d50d36cce74047cf32c3f93a745f698/remove_leading_place.py#L49

More information:
* [MITRE](https://cwe.mitre.org/data/definitions/611.html)
* [OWASP vulnerability description](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing)
* [OWASP guidance on parsing xml files](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#python)
